### PR TITLE
Ratan/fix ckzg errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "contracts/lib/forge-std"]
 	path = contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba1c79677c9ce51c8d45e20845b05e6fb070ea2c863fba03ad6af2c778474bd"
+dependencies = [
+ "alloy-core",
+ "alloy-eips",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-transport",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529fc6310dc1126c8de51c376cbc59c79c7f662bd742be7dc67055d5421a81b4"
+dependencies = [
+ "alloy-primitives 0.7.7",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4b0fc6a572ef2eebda0a31a5e393d451abda703fec917c75d9615d8c978cf2"
+dependencies = [
+ "alloy-primitives 0.7.7",
+ "alloy-rlp",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6f34930b7e3e2744bcc79056c217f00cb2abb33bc5d4ff88da7623c5bb078b"
+dependencies = [
+ "alloy-primitives 0.7.7",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0e3c2913b53ca41293c873f0da8be8eaaeb2b134f31f61d1d01311a0afb923"
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +189,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba31bae67773fd5a60020bea900231f8396202b7feca4d0c70c6b59308ab4a8"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -197,6 +267,35 @@ dependencies = [
  "alloy-sol-macro",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b51a291f949f755e6165c3ed562883175c97423703703355f4faa4b7d0a57c"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d65871f9f1cafe1ed25cde2f1303be83e6473e995a2d56c275ae4fcce6119c"
+dependencies = [
+ "alloy-transport",
+ "url",
 ]
 
 [[package]]
@@ -2651,6 +2750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,11 +3135,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "helios-2-program"
+name = "helios-program"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-types",
  "common",
  "consensus-core",
  "hex",
@@ -3045,9 +3148,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "helios-2-script"
+name = "helios-script"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "anyhow",
  "cargo-machete",
  "clap",
@@ -6176,8 +6280,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha2-v0.9.9#db82a4848f8d033eab544255e1efa036cc06f054"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -6189,8 +6292,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?branch=patch-sha2-v0.10.8#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -6357,7 +6459,7 @@ dependencies = [
 [[package]]
 name = "sp1-build"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/succinctlabs/sp1.git?tag=v1.0.0-rc.1#6be0efa16f8cc56a9c7a286fef71d8f0b51f2c62"
+source = "git+https://github.com/succinctlabs/sp1?tag=v1.0.0-rc.1#6be0efa16f8cc56a9c7a286fef71d8f0b51f2c62"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6439,8 +6541,6 @@ dependencies = [
 name = "sp1-helios-primitives"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-types",
  "common",
  "consensus-core",
  "eyre",
@@ -6454,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "sp1-helper"
 version = "1.0.0-rc.1"
-source = "git+https://github.com/succinctlabs/sp1.git?tag=v1.0.0-rc.1#6be0efa16f8cc56a9c7a286fef71d8f0b51f2c62"
+source = "git+https://github.com/succinctlabs/sp1?tag=v1.0.0-rc.1#6be0efa16f8cc56a9c7a286fef71d8f0b51f2c62"
 dependencies = [
  "cargo_metadata",
  "chrono",
@@ -7107,9 +7207,9 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/sp1-patches/tiny-keccak?branch=patch-v2.0.2#bf0b28f63510a90c7b6c21ac6ff461c93ecd2331"
 dependencies = [
+ "cfg-if",
  "crunchy",
 ]
 
@@ -7197,6 +7297,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "./primitives",
-    "./program",
-    "./script",
-]
+members = ["./primitives", "./program", "./script"]
 resolver = "2"
 
 [workspace.package]
@@ -13,13 +9,13 @@ license = "MIT"
 [workspace.dependencies]
 dotenv = "0.15.0"
 eyre = "0.6.12"
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", tag = "v1.0.1"}
+sp1-sdk = { git = "https://github.com/succinctlabs/sp1.git", tag = "v1.0.1" }
 sp1-zkvm = { git = "https://github.com/succinctlabs/sp1.git", tag = "v1.0.1" }
 tokio = "1.38.0"
-helios = { git = "https://github.com/succinctlabs/helios.git"}
-common = {git = "https://github.com/succinctlabs/helios.git"}
-consensus-core = {git = "https://github.com/succinctlabs/helios.git"}
-sp1-helios-primitives = {path = "./primitives"}
+helios = { git = "https://github.com/succinctlabs/helios.git" }
+common = { git = "https://github.com/succinctlabs/helios.git" }
+consensus-core = { git = "https://github.com/succinctlabs/helios.git" }
+sp1-helios-primitives = { path = "./primitives" }
 tracing = "0.1.37"
 serde = "1.0.203"
 ssz-rs = { package = "ssz_rs", version = "0.9.0" }
@@ -39,3 +35,9 @@ alloy = { version = "0.1.1", features = ["full"] }
 anyhow = "1.0.86"
 reqwest = "0.12.5"
 cargo-machete = "0.6.2"
+sp1-helper = { git = "https://github.com/succinctlabs/sp1-helper.git", tag = "v1.0.0-rc.1" }
+
+[patch.crates-io]
+sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,14 @@ clap = "4.5.9"
 log = "0.4.22"
 env_logger = "0.11.3"
 # alloy-primitives = "0.7.7"
-alloy = { version = "0.1.1", features = ["full"] }
+alloy = { version = "0.1.1", default-features = false, features = [
+    "transports",
+    "providers",
+] }
 anyhow = "1.0.86"
 reqwest = "0.12.5"
 cargo-machete = "0.6.2"
-sp1-helper = { git = "https://github.com/succinctlabs/sp1-helper.git", tag = "v1.0.0-rc.1" }
+sp1-helper = { git = "https://github.com/succinctlabs/sp1", tag = "v1.0.0-rc.1" }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -12,4 +12,3 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 consensus-core = { workspace = true }
 common = { workspace = true }
-alloy = { workspace = true }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -4,17 +4,12 @@ name = "sp1-helios-primitives"
 edition = "2021"
 
 [dependencies]
-eyre = {workspace = true}
-ssz-rs = {workspace = true}
-hex = {workspace = true}
-serde_with = {workspace = true}
-serde = {workspace = true}
-serde_json = {workspace = true}
-consensus-core = {workspace = true}
-common = {workspace = true}
-alloy = {workspace = true}
-
-[patch.crates-io]
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+eyre = { workspace = true }
+ssz-rs = { workspace = true }
+hex = { workspace = true }
+serde_with = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+consensus-core = { workspace = true }
+common = { workspace = true }
+alloy = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,20 +1,15 @@
 [package]
 version = "0.1.0"
-name = "helios-2-program"
+name = "helios-program"
 edition = "2021"
 
 [dependencies]
-sp1-zkvm = {workspace = true}
-common = {workspace = true}
-consensus-core = {workspace = true}
-serde_cbor = {workspace = true}
-sp1-helios-primitives = {workspace = true}
+sp1-zkvm = { workspace = true }
+common = { workspace = true }
+consensus-core = { workspace = true }
+serde_cbor = { workspace = true }
+sp1-helios-primitives = { workspace = true }
 # alloy-sol-types = "0.7.7"
-ssz-rs = {workspace = true}
+ssz-rs = { workspace = true }
 # alloy-primitives = "0.7.7"
-hex = {workspace = true}
-
-[patch.crates-io]
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+hex = { workspace = true }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-17"
+channel = "1.79"
 components = ["llvm-tools", "rustc-dev"]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 version = "0.1.0"
-name = "helios-2-script"
+name = "helios-script"
 edition = "2021"
 
 
@@ -18,34 +18,29 @@ name = "operator"
 path = "./bin/operator.rs"
 
 [dependencies]
-dotenv = {workspace = true}
-eyre = {workspace = true}
-sp1-sdk = {workspace = true}
-tokio = {workspace = true}
-helios = {workspace = true}
-sp1-helios-primitives = {path = "../primitives"}
-tracing = {workspace = true}
-serde = {workspace = true}
-ssz-rs = {workspace = true}
-thiserror = {workspace = true}
-ethers-core = {workspace = true}
-zduny-wasm-timer = {workspace = true}
-serde_cbor = {workspace = true}
-hex = {workspace = true}
+dotenv = { workspace = true }
+eyre = { workspace = true }
+sp1-sdk = { workspace = true }
+tokio = { workspace = true }
+helios = { workspace = true }
+sp1-helios-primitives = { path = "../primitives" }
+tracing = { workspace = true }
+serde = { workspace = true }
+ssz-rs = { workspace = true }
+thiserror = { workspace = true }
+ethers-core = { workspace = true }
+zduny-wasm-timer = { workspace = true }
+serde_cbor = { workspace = true }
+hex = { workspace = true }
 # alloy-sol-types = {workspace = true}
-clap = {workspace = true}
-log = {workspace = true}
-env_logger = {workspace = true}
+clap = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 # alloy-primitives = {workspace = true}
-alloy = {workspace = true}
-anyhow = {workspace = true}
-reqwest = {workspace = true}
-cargo-machete = {workspace = true}
+alloy = { workspace = true }
+anyhow = { workspace = true }
+reqwest = { workspace = true }
+cargo-machete = { workspace = true }
 
 [build-dependencies]
-sp1-helper = { git = "https://github.com/succinctlabs/sp1.git", tag = "v1.0.0-rc.1" }
-
-[patch.crates-io]
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.9.9" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+sp1-helper = { workspace = true }


### PR DESCRIPTION
If you read this error, you can see that `alloy-consensus` has a conflicting `c-kzg` version with `revm`. You don't need `alloy-consensus`, so you should attempt to configure it out in the feature flags. I did this by looking at the feature flags that were used, and picking ones that allowed me to compile `sp1-telepathy`.