### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/contracts/.github/workflows/test.yml
+++ b/contracts/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Updated actions/checkout from v3 to v4 in contracts/.github/workflows/test.yml to stay current with the latest version. This ensures our CI workflow benefits from the newest features and security enhancements

[actions/checkout@v4 Release Notes](https://github.com/actions/checkout/releases/tag/v4.2.2)
