### PR TITLE
Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchai…

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable


### PR DESCRIPTION
GitHub Action from deprecated `actions-rs/toolchain@v1` to actively maintained `dtolnay/rust-toolchain@stable` for better compatibility and support.  
Official repo for replacement: https://github.com/dtolnay/rust-toolchain-action








