### PR TITLE
docs: refresh book content + add trust model section

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -3,5 +3,7 @@
 - [Introduction](./introduction.md)
 - [Deployment](./deployment.md)
 - [Components](./components.md)
+- [Trust Model](./trust-model.md)
+- [Receipts Route (Planned)](./receipts.md)
 - [FAQ](./faq.md)
 - [Reproducible Builds](./reproducible-builds.md)

--- a/book/components.md
+++ b/book/components.md
@@ -1,10 +1,49 @@
 # Components
 
-An SP1 Helios implementation has a few key components:
-- An `SP1Helios` contract. Contains the logic for verifying SP1 Helios proofs, storing the latest data from the Ethereum beacon chain, including the headers, execution state roots and sync committees.
-- An `SP1Verifier` contract. Verifies arbitrary SP1 programs. Most chains will have canonical deployments
-upon SP1's mainnet launch. Until then, users can deploy their own `SP1Verifier` contracts to verify
-SP1 programs on their chain. The SP1 Helios implementation will use the `SP1Verifier` contract to verify
-the proofs of the SP1 Helios program.
-- The SP1 Helios program. An SP1 program that verifies the consensus of a source chain in the execution environment of a destination chain using the `helios` library.
-- The operator. A Rust script that fetches the latest data from a deployed `SP1Helios` contract and an Ethereum beacon chain, determines the block to request, requests for/generates a proof, and relays the proof to the `SP1Helios` contract.
+An SP1 Helios deployment has four moving parts.
+
+## `SP1Helios` contract
+
+Lives on the destination chain. Stores the latest finalized beacon header,
+execution state root, sync committee hash per period, and any attested
+storage slots. Holds two verification keys — `lightClientVkey` for the
+consensus update program and `storageSlotVkey` for the standalone storage
+proof program — plus the address of an SP1 verifier contract. A `guardian`
+address can rotate either vkey (and the guardian itself can be relinquished).
+
+Exposes two entrypoints:
+- `update(...)` — applies a consensus update produced by the `light_client`
+  guest program, advancing `head`, `executionStateRoot`, and the sync
+  committee mapping, and optionally writing storage slots bundled with the
+  update.
+- `updateStorageSlot(...)` — verifies a standalone storage proof produced
+  by the `storage` guest program against a state root the contract already
+  trusts, and writes the slots.
+
+## SP1 verifier contract
+
+The contract address stored in `SP1Helios.verifier` — verifies any SP1
+proof against a given vkey and public values. The canonical SP1 PLONK
+verifier addresses per chain are listed in the [SP1 contract addresses
+docs](https://docs.succinct.xyz/docs/sp1/verification/contract-addresses).
+Deployers can substitute their own deployment or `SP1MockVerifier` for
+local testing.
+
+## SP1 Helios guest programs
+
+Two programs ship in `program/`:
+- `light_client` — runs Helios consensus verification (sync-committee
+  signature check, finality proof, sync-committee-rotation proof, header
+  validity) and, in the same proof, verifies any requested source-chain
+  storage slots against the new execution state root. Commits a
+  `ProofOutputs` struct as public values.
+- `storage` — verifies storage slot MPT proofs against a state root passed
+  in as input. Used for ad-hoc storage proofs after a state root is
+  already trusted by the contract. Commits a `StorageProofOutputs` struct.
+
+## Operator
+
+A Rust binary (`script/bin/operator.rs`) that fetches the contract's
+current head, calls a beacon node to assemble the next consensus update,
+runs the `light_client` guest, and submits the resulting proof to
+`SP1Helios.update`. Runs on a configurable interval (default 5 minutes).

--- a/book/deployment.md
+++ b/book/deployment.md
@@ -2,59 +2,78 @@
 
 ## Overview
 
-SP1 Helios verifies the consensus of a source chain in the execution environment of a destination chain. For example, you can run an SP1 Helios light client on Polygon that verifies Ethereum Mainnet's consensus.
+SP1 Helios verifies the consensus of a source chain in the execution
+environment of a destination chain. For example, you can run SP1 Helios on
+Polygon that verifies Ethereum Mainnet's consensus.
 
 ## Prerequisites
 
-- [Foundry](https://book.getfoundry.sh/getting-started/installation)
-- [SP1](https://docs.succinct.xyz/getting-started/install.html)
+- [Foundry](https://getfoundry.sh/)
+- [SP1](https://docs.succinct.xyz/docs/sp1/getting-started/install)
+- A funded deployer key (private key or Ledger) on the destination chain
 
-## Steps
+## 1. Consensus RPC
 
-### 1. Consensus RPC Setup
+The deployment requires a beacon-chain RPC for the source chain that
+supports the [Altair light-client sync protocol](https://github.com/ethereum/consensus-specs/blob/master/specs/altair/light-client/sync-protocol.md)
+endpoints (`/eth/v1/beacon/light_client/*`). Not all consensus clients
+expose these by default — Nimbus does; other clients may need a CLI flag
+or a recent enough version. Options:
 
-To run SP1 Helios, you need a Beacon Chain node for your source chain. For example, to run an Ethereum mainnet light client, you need an Ethereum mainnet beacon node.
+1. A managed provider that exposes the light-sync endpoints (e.g.
+   [Chainstack](https://chainstack.com/) Ethereum beacon nodes).
+2. Run your own node configured to expose the light-sync endpoints.
+3. A community list of public endpoints lives at
+   <https://s1na.github.io/light-sync-endpoints>; these are best-effort
+   and not recommended for production.
 
-The beacon chain node must support the RPC methods for the [Altair light client protocol](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md). As of 10/15/24, Nimbus is the only consensus client that supports these "light sync" endpoints by default.
+The chosen URL is `SOURCE_CONSENSUS_RPC` in the next steps.
 
-There are a few options for setting up a consensus RPC with "light sync" endpoints:
+## 2. Deploy the contract
 
-1. Get an RPC from a provider running Nimbus nodes. [Chainstack](https://chainstack.com/) is currently the only provider we're aware of that supports this. Set up a node on Chainstack and use the consensus client endpoint for an Ethereum mainnet node.
-2. Run a Nimbus eth2 beacon node. Instructions [here](https://nimbus.guide/el-light-client.html).
-3. There is a community-maintained list of Ethereum Beacon Chain light sync endpoints [here](https://s1na.github.io/light-sync-endpoints). These endpoints are not guaranteed to work, and are often unreliable.
-
-The RPC you just set up will be used as the `SOURCE_CONSENSUS_RPC_URL` in the next step.
-
-### 2. Deploy Contract
-
-Deploy the SP1 Helios contract, note, this requires [Foundry](https://getfoundry.sh/), and a [PLONK verifier gateway](https://docs.succinct.xyz/docs/sp1/verification/contract-addresses):
-
-```bash
-cargo run --bin genesis -- [--private-key] [--ledger] [--etherscan-api-key] <--sp1-verifier-address> <--guardian-address> <--source-consensus-rpc> <--source-chain-id> 
-```
-
-When the script completes, take note of the light client contract address printed to the terminal.
-
-### 3. Run Light Client
-
-To run the operator, which generates proofs and keeps the light client updated with chain state:
+`bin/genesis` queries the consensus RPC, builds an initial trusted
+checkpoint (`genesis.json`), and invokes `forge script` to deploy
+`SP1Helios` with those parameters baked in. The PLONK verifier address
+for your destination chain is in the [SP1 contract addresses
+docs](https://docs.succinct.xyz/docs/sp1/verification/contract-addresses).
 
 ```bash
-cargo run --release --bin operator -- <--rpc-url> <--contract-address> <--source-chain-id> <--source-consensus-rpc> <--private-key>
+cargo run --bin genesis -- \
+  --rpc-url <DESTINATION_RPC_URL> \
+  --source-consensus-rpc <SOURCE_CONSENSUS_RPC> \
+  --source-chain-id 1 \
+  --sp1-verifier-address <SP1_VERIFIER_ADDRESS> \
+  --guardian-address <GUARDIAN_ADDRESS> \
+  --private-key <DEPLOYER_PK>
+  # or: --ledger [--ledger-path N]
+  # optional: --slot <SLOT> --etherscan-api-key <KEY>
 ```
 
-Internally the Operator program uses the [SP1EnvProver](https://docs.rs/sp1-sdk/latest/sp1_sdk/env/struct.EnvProver.html#method.new), the docs will explain how to setup the ENV vars.
+The forge broadcast prints the deployed `SP1Helios` address.
 
+## 3. Run the operator
 
-If successful, you should see logs indicating that the consensus state is being updated:
+The operator polls `SP1Helios.head`, fetches updates from the consensus
+RPC, generates a proof, and submits `update(...)`:
 
-```shell
-[2024-10-15T21:01:19Z INFO  operator] Starting SP1 Helios operator
-[2024-10-15T21:01:20Z WARN  helios::consensus] checkpoint too old, consider using a more recent block
-[2024-10-15T21:01:20Z INFO  operator] Contract is up to date. Nothing to update.
-[2024-10-15T21:01:20Z INFO  operator] Sleeping for 5 minutes
-...
-[2024-10-15T21:06:35Z INFO  operator] New head: 6107648
-[2024-10-15T21:06:50Z INFO  operator] Transaction hash: 0x4a0dfa2922704295ed59bf16840454858a4d17225cdf613387de7605b5a41520
-[2024-10-15T21:06:50Z INFO  operator] Sleeping for 5 minutes
+```bash
+cargo run --release --bin operator -- \
+  --rpc-url <DESTINATION_RPC_URL> \
+  --contract-address <SP1HELIOS_ADDRESS> \
+  --source-chain-id 1 \
+  --source-consensus-rpc <SOURCE_CONSENSUS_RPC> \
+  --private-key <RELAYER_PK> \
+  --loop-delay-mins 5
+```
+
+Proving uses [`sp1_sdk::EnvProver`](https://docs.rs/sp1-sdk/), which reads
+prover configuration (network vs. local, network endpoint, keys, etc.)
+from environment variables — see the SP1 SDK docs for the available knobs.
+
+Sample log output:
+
+```
+INFO operator: Starting SP1 Helios operator
+INFO operator: Updating to new head block: 6107712 from 6107648
+INFO operator: Successfully updated to new head block! Tx hash: 0x4a0d...
 ```

--- a/book/faq.md
+++ b/book/faq.md
@@ -1,9 +1,42 @@
 # Frequently Asked Questions
 
-## How do I prove data on Ethereum against an SP1 Helios light client?
+## How do I prove data on the source chain against an SP1 Helios light client?
 
-The SP1 Helios light client validates the Ethereum beacon chain's headers are signed correctly by
-the Altair sync committee. The [Helios library](https://github.com/a16z/helios) verifies that the execution payload in the beacon chain's header is correct [here](https://github.com/a16z/helios/blob/8cd29787857303c6f455c08e948a694cc2e8f46d/ethereum/consensus-core/src/consensus_core.rs#L481-L507).
+After an `update(...)` lands on the destination contract, the source
+chain's execution state root for that block is available at
+`SP1Helios.executionStateRoots(blockNumber)`. Use standard Ethereum
+[Merkle Patricia Trie](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)
+proofs against that root to prove an account's `TrieAccount` and then any
+storage slot value. See the [Trust Model](./trust-model.md) chapter for
+the full chain of trust, and `program/src/storage.rs` for a reference
+implementation.
 
-You can use storage proofs to Merkle prove data in the Merkle Patricia Trie against the execution state root.
+## Where in Helios is the consensus verification?
 
+The free functions `verify_update` / `apply_update` and
+`verify_finality_update` / `apply_finality_update` in
+[`helios-consensus-core`](https://github.com/a16z/helios/blob/master/ethereum/consensus-core/src/consensus_core.rs)
+are the entrypoints the SP1 Helios guest calls. They run sync-committee
+signature verification, finality and sync-committee-rotation Merkle
+proofs, and header validity checks.
+
+## Which source chains are supported?
+
+The current ELFs target Ethereum mainnet (`MainnetConsensusSpec` and
+chain ID 1 are the defaults). The guest is generic over Helios's
+`ConsensusSpec` trait, so other beacon-chain networks (e.g. testnets)
+work in principle but require building new ELFs and re-deriving vkeys.
+
+## Can I have multiple `SP1Helios` instances tracking different source chains?
+
+Yes — deploy one contract per source chain, each with its own
+`sourceChainId`, initial checkpoint, and (if you've built different
+guest ELFs) vkeys.
+
+## What happens if the operator goes offline?
+
+The contract stops advancing but remains consistent. When the operator
+returns, it generates a proof spanning the gap. The 32-slot
+checkpoint-boundary requirement means the operator should reorganize
+its request to land on a checkpoint slot; the guest already enforces
+this.

--- a/book/introduction.md
+++ b/book/introduction.md
@@ -2,9 +2,25 @@
 
 ## Overview
 
-Implementation of an ZK Ethereum light client using the Altair sync committee with [SP1](https://github.com/succinctlabs/sp1) and [Helios](https://github.com/a16z/helios).
+SP1 Helios is a ZK light client for Ethereum's beacon chain. It runs the
+[Helios](https://github.com/a16z/helios) consensus verification logic inside
+an [SP1](https://github.com/succinctlabs/sp1) zkVM program, producing a
+succinct proof that a given beacon block header — and the execution state
+root committed inside it — was attested by the Altair sync committee.
 
-- `/program`: The SP1 Helios program.
-- `/primitives`: Libraries for types and helper functions used in the program.
-- `/script`: Scripts for getting the contract's genesis parameters and deploying the operator to 
-    update the light client.
+A deployed `SP1Helios` contract on any EVM destination chain consumes these
+proofs to maintain an up-to-date view of the source chain's finalized
+headers, execution state roots, and sync committees. Downstream contracts
+can use the attested execution state root to verify source-chain storage
+via standard MPT proofs.
+
+## Repository layout
+
+- `program/` — the SP1 guest programs (`light_client` and `storage`).
+- `primitives/` — shared types (`ProofInputs`, `ProofOutputs`,
+  `StorageProofOutputs`, `ContractStorage`) and the MPT verification helper.
+- `script/` — host binaries: `genesis` (deploy-time bootstrap),
+  `operator` (proof generation loop), `vkey` (vkey inspection).
+- `contracts/` — `SP1Helios.sol` and its Foundry deploy script.
+- `elf/` — built guest ELFs consumed by the host binaries via
+  `include_bytes!`.

--- a/book/receipts.md
+++ b/book/receipts.md
@@ -1,0 +1,25 @@
+# Receipts Route (Planned)
+
+The current programs attest **state** — the execution state root and any
+MPT-verified storage slot values. State is the right primitive for
+balances, slot reads, and any value with on-chain canonical storage.
+
+A second, parallel route for **receipts** is planned to support
+event-driven use cases (e.g. proving a log was emitted by a specific
+contract at a specific block on the source chain). The pattern mirrors
+the existing storage route:
+
+1. Each canonical execution-payload header commits to a `receipts_root`
+   alongside `state_root`. A future `light_client` revision would
+   commit `receiptsRoot` into `ProofOutputs` so the `SP1Helios`
+   contract anchors it the same way it currently anchors
+   `executionStateRoot`.
+2. A `receipts` guest program (counterpart to the existing `storage`
+   program) would verify MPT inclusion proofs of a receipt against
+   the trusted `receiptsRoot`, then verify any specific log within
+   the receipt's log list.
+
+Composition details — bundling vs. standalone proofs, batch shapes,
+ABI for `ReceiptProofOutputs` — are not finalized. This section will be
+expanded once the design lands. Reach out if you have a concrete use
+case that would help inform it.

--- a/book/reproducible-builds.md
+++ b/book/reproducible-builds.md
@@ -1,45 +1,54 @@
 # Reproducible Builds
 
-## Overview
-
-When deploying SP1 Helios in production, it's important to ensure that the program used when generating proofs is reproducible.
+The two guest ELFs in `elf/` (`light_client` and `storage`) determine
+the vkeys stored in `SP1Helios`. For a deployment to be auditable, those
+ELFs must be reproducible from source.
 
 ## Prerequisites
 
-You first need to install the [cargo prove](https://docs.succinct.xyz/getting-started/install.html#option-1-prebuilt-binaries-recommended) toolchain.
-
-Ensure that you have the latest version of the toolchain by running:
+The [`cargo prove`](https://docs.succinct.xyz/docs/sp1/getting-started/install)
+toolchain. Install or update with:
 
 ```bash
+curl -L https://sp1.succinct.xyz | bash
 sp1up
-```
-
-Confirm that you have the toolchain installed by running:
-
-```bash
 cargo prove --version
 ```
 
-## Verify the SP1 Helios binary
-
-To build the SP1 Helios binary, first ensure that Docker is running.
+Reproducible builds happen inside a Docker image, so a working Docker
+daemon is required:
 
 ```bash
 docker ps
 ```
 
-Then build the binaries:
+## Build
+
+Build both guests with the SP1 toolchain version pinned to the one
+declared in the workspace `Cargo.toml` (`sp1-sdk` / `sp1-build`). Run
+from the workspace root:
 
 ```bash
 cd program
-
-# Builds the SP1 Helios binary using the corresponding Docker tag, output directory and ELF name.
-cargo prove build --docker --tag v4.1.7 --elf-name sp1-helios-elf --output-directory ../elf
+cargo prove build --docker --tag v<SP1_VERSION> --output-directory ../elf
 ```
 
-Now, verify the binaries by confirming the output of `vkey` matches the vkeys on the contract. The `vkey` program outputs the verification key
-based on the ELF in `/elf`.
+Replace `<SP1_VERSION>` with the version in `Cargo.toml` (for example,
+`v5.2.4`). Both `light_client` and `storage` binaries will be written
+to `../elf/`. The output should be byte-identical across machines.
+
+## Verify the vkeys
+
+The `vkey` script reads each ELF and prints its verification key:
 
 ```bash
 cargo run --bin vkey --release
 ```
+
+The printed `Light Client Verifying Key` must equal `SP1Helios.lightClientVkey()`
+on the deployed contract, and `Storage Verifying Key` must equal
+`SP1Helios.storageSlotVkey()`. If they do not match, the deployment is
+either using a different guest version or a non-reproducible build — do
+not trust it without resolving the discrepancy (e.g. by asking the
+guardian to rotate the vkeys via `updateLightClientVkey` /
+`updateStorageSlotVkey`).

--- a/book/trust-model.md
+++ b/book/trust-model.md
@@ -1,0 +1,134 @@
+# Trust Model
+
+This section describes, end-to-end, what an SP1 Helios deployment trusts
+and why. The goal is to make explicit what an integrator can take as given
+when they read a value off the contract.
+
+The chain of trust has four links:
+
+1. A deploy-time trusted checkpoint that seeds the contract.
+2. An SP1 proof, over every update, that attests a new finalized header
+   was correctly derived from the previous trusted state.
+3. The on-chain contract pinning the proof's public values to its own
+   storage so the proof can only verify against the state the contract
+   already believes.
+4. Standard MPT verification against the attested execution state root
+   for any downstream storage access.
+
+## 1. Deploy-time trusted checkpoint
+
+`SP1Helios` is constructed with an `InitParams` struct (see
+`contracts/src/SP1Helios.sol`) that fixes:
+
+- `head`, `header`, `executionStateRoot`, `executionBlockNumber`
+- `syncCommitteeHash` for the period containing `head`
+- `lightClientVkey`, `storageSlotVkey`
+- The SP1 `verifier` address and `guardian`
+
+These values are produced by `bin/genesis`, which queries a beacon RPC
+for a recent finalized checkpoint and writes `genesis.json` for the
+forge deploy script. **Whoever deploys is trusted to seed an honest
+initial state.** Once seeded, every subsequent update is verified by
+zero-knowledge proof — no further off-chain trust is required from the
+operator running the relayer.
+
+The `guardian` retains the ability to rotate `lightClientVkey` and
+`storageSlotVkey` (e.g. to upgrade the guest program). The guardian can
+also relinquish itself, making the deployment immutable.
+
+## 2. What the SP1 proof attests on each update
+
+The `light_client` guest program runs the Helios consensus verification
+logic against inputs supplied by the operator and commits a
+`ProofOutputs` struct (`primitives/src/types.rs`) as public values:
+
+| Field                   | Meaning                                                   |
+| ----------------------- | --------------------------------------------------------- |
+| `prevHeader`            | The beacon header the proof was built **from**            |
+| `prevHead`              | The slot of that previous header                          |
+| `prevSyncCommitteeHash` | The sync committee that signed the chain of updates       |
+| `newHeader`             | The new finalized beacon header                           |
+| `newHead`               | The slot of the new header (must be a multiple of 32)     |
+| `executionStateRoot`    | The execution state root committed inside the new header  |
+| `executionBlockNumber`  | The execution block number for that state root            |
+| `syncCommitteeHash`     | The sync committee hash for the new period                |
+| `nextSyncCommitteeHash` | The next-period sync committee hash, if rotated           |
+| `storageSlots`          | Any storage slots requested by the operator, MPT-verified against `executionStateRoot` in the same proof |
+
+The guest, in `program/src/light_client.rs`, applies each
+`Update`/`FinalityUpdate` in turn via `verify_update` / `apply_update`
+from `helios-consensus-core`, asserts the new head is strictly greater
+than the previous head and lies on a 32-slot checkpoint boundary, then
+verifies each requested storage slot's MPT proof against the new
+execution state root before committing the `ProofOutputs`.
+
+## 3. How the contract anchors trust
+
+`SP1Helios.update` does not accept the previous-state fields from the
+caller. It reads them from its own storage:
+
+```solidity
+ProofOutputs memory po = ProofOutputs({
+    prevHeader: headers[head],
+    prevHead: head,
+    prevSyncCommitteeHash: syncCommittees[getSyncCommitteePeriod(head)],
+    newHead: newHead,
+    newHeader: newHeader,
+    /* ... */
+});
+ISP1Verifier(verifier).verifyProof(lightClientVkey, abi.encode(po), proof);
+```
+
+The proof can only verify if the public values it was generated over
+match this exact struct byte-for-byte. So:
+
+- A proof built from an attacker-chosen previous header cannot verify —
+  the contract would have substituted its own `headers[head]`.
+- The previous sync-committee hash used inside the guest is pinned to
+  whatever the contract last stored. The guest's signature check
+  therefore runs against a committee the contract already trusts.
+
+After the proof verifies, the contract writes the new head, header,
+state root, sync committees, and storage slots. Sync committees for
+future periods, if already set, must match (`NextSyncCommitteeMismatch`
+revert) — preventing inconsistent rotations.
+
+The standalone `updateStorageSlot` entrypoint uses the same pattern:
+the storage root is filled in from `executionStateRoots[blockNumber]`,
+which the contract already trusts because it was committed by a prior
+verified `light_client` proof. A caller cannot supply their own root.
+
+## 4. Downstream storage verification
+
+Once `SP1Helios.executionStateRoots[blockNumber]` is populated, any
+contract on the destination chain can prove a value at any source-chain
+storage slot at that block by passing standard MPT proofs through the
+`storage` program (or by re-implementing the same check off-chain and
+re-verifying inside a different SP1 program). The mechanics mirror
+`program/src/storage.rs`:
+
+1. Hash the contract address with `keccak256` and verify a state-trie
+   proof against `executionStateRoot`, yielding the contract's
+   `TrieAccount` (and therefore its `storage_root`).
+2. For each slot key, hash with `keccak256` and verify a storage-trie
+   proof against `storage_root`, yielding the slot's value.
+
+These are the canonical Ethereum MPT layouts; no SP1-specific format
+is involved. The only trusted input is `executionStateRoot`, which the
+SP1 proof attests came from a sync-committee-signed beacon header.
+
+## Why each link is trustless
+
+| Link                                                  | Trust assumption                                              |
+| ----------------------------------------------------- | ------------------------------------------------------------- |
+| Deploy-time checkpoint → trusted initial state        | Deployer (verifiable against any beacon node at deploy time)  |
+| Initial state → every later state                     | Soundness of SP1, soundness of Helios consensus verification, 2/3 of source-chain sync committee honest (the standard Altair assumption) |
+| Contract storage → proof public values                | EVM execution and SP1 verifier correctness                    |
+| `executionStateRoot` → source-chain storage slot value | Ethereum MPT inclusion / `keccak256` collision resistance     |
+
+The relayer that runs `bin/operator` is **not** trusted: it cannot
+forge a proof that verifies against the contract's pinned previous state,
+and it cannot censor the chain indefinitely without becoming observable
+(no head advancement). The only trust placed in any off-chain party is
+the deployer's choice of initial checkpoint and the guardian's vkey
+rotation authority — both of which are explicit and inspectable on chain.


### PR DESCRIPTION
## Summary
Refreshes `book/` end-to-end to match current code. No behavior changes.

- Updated introduction/components/deployment/faq/reproducible-builds to match current code (two ELFs `light_client` + `storage`, EnvProver setup, correct CLI args including the missing `--rpc-url` on `genesis`, removed stale dated Nimbus claim and `--elf-name sp1-helios-elf` syntax).
- Added **Trust Model** chapter — end-to-end walk of deploy-time checkpoint → SP1 proof → contract anchoring → downstream MPT for integrators.
- Added **Receipts Route (Planned)** placeholder — short note that the same pattern will extend to receipts-trie attestation; specifics deferred.
- Fixed broken consensus-specs `dev` branch link (now `master`) and stale helios commit-pinned deep link in FAQ.

Out of scope: integrating into `docs.succinct.xyz` (separate effort).